### PR TITLE
fix uff runner : only copy memory of current batch size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ sudo: required
 
 before_install:
 - docker info
+- sudo apt update
 - sudo apt install -y swig # FIXME: can't install libopencv-dev on travis CI
 - pip install -r requirements.txt
 - pip install pycocotools  # must be installed after cython is installed

--- a/scripts/run-uff-cpp.sh
+++ b/scripts/run-uff-cpp.sh
@@ -11,7 +11,7 @@ repeat=20
 gksize=13
 
 run_batch_example() {
-    local BIN=$(pwd)/cmake-build/$(uname -s)/example
+    local BIN=$(pwd)/cmake-build/$(uname -s)/example-batch-detector
     local IMAGES=$(echo $@ | tr ' ' ',')
     local batch_size=4
     ${BIN} \

--- a/src/std_cuda_tensor.hpp
+++ b/src/std_cuda_tensor.hpp
@@ -45,6 +45,14 @@ template <typename R, rank_t r> class basic_cuda_tensor
                    cudaMemcpyHostToDevice);
     }
 
+    void partialFromHost(void *buffer, int batch_size, int max_batch_size)
+    {
+        TRACE("basic_cuda_tensor::partialFromHost");
+        cudaMemcpy(data_.get(), buffer,
+                   count / max_batch_size * batch_size * sizeof(R),
+                   cudaMemcpyHostToDevice);
+    }
+
     void toHost(void *buffer)
     {
         TRACE("basic_cuda_tensor::toHost");
@@ -52,10 +60,18 @@ template <typename R, rank_t r> class basic_cuda_tensor
                    cudaMemcpyDeviceToHost);
     }
 
+    void partialToHost(void *buffer, int batch_size, int max_batch_size)
+    {
+        TRACE("basic_cuda_tensor::partialToHost");
+        cudaMemcpy(buffer, data_.get(),
+                   count / max_batch_size * batch_size * sizeof(R),
+                   cudaMemcpyDeviceToHost);
+    }
+
   private:
     const shape<r> shape_;
     const size_t count;
-    const std::unique_ptr<R, cuda_mem_deleter> data_;
+    std::unique_ptr<R, cuda_mem_deleter> data_;
 };
 
 template <typename R, rank_t r> using cuda_tensor = basic_cuda_tensor<R, r>;


### PR DESCRIPTION
It may trigger a memory error when batch_size != max_batch_size. 
This PR fixes that.