### PR TITLE
Import get_op in example-inference-2.py

### DIFF
--- a/examples/example-inference-2.py
+++ b/examples/example-inference-2.py
@@ -12,7 +12,7 @@ import tensorlayer as tl
 
 sys.path.append('.')
 
-from openpose_plus.inference.common import measure, plot_humans, read_imgfile, load_graph
+from openpose_plus.inference.common import measure, plot_humans, read_imgfile, load_graph, get_op
 from openpose_plus.inference.estimator import TfPoseEstimator
 
 


### PR DESCRIPTION
get_op does not exists in the scope of this script, so it need to be imported.